### PR TITLE
Support returning a specific http response code

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ Optional parameters are also... an option:
     ],
 ```
 
+It is also possible to optionally specify which http response code is used when performing the redirect. By default the ```301 Moved Permanently``` response code is set. You may override this using the following syntax:   
+
+```php
+    'redirects' => [
+       'old-page' => ['/new-page', 302],
+    ],
+```
+
 ## Creating your own redirector
 
 By default this package will use the `Spatie\MissingPageRedirector\Redirector\ConfigurationRedirector` which will get its redirects from the config file. If you want to use another source for your redirects (for example a database) you can create your own redirector.

--- a/src/MissingPageRouter.php
+++ b/src/MissingPageRouter.php
@@ -35,15 +35,11 @@ class MissingPageRouter
 
             $this->router->get($missingUrl, function () use ($redirects) {
 
-                if (is_array($redirects)) {
-                    $redirectUrl = $this->resolveRouterParameters($redirects[0]);
-                } else {
-                    $redirectUrl = $this->resolveRouterParameters($redirects);
-                }
+                return redirect()->to(
+                    $this->getRedirectUrlFromRedirects($redirects),
+                    $this->getStatusCodeFromRedirects($redirects)
+                );
 
-                $statusCode = is_array($redirects) ? $redirects[1] : Response::HTTP_MOVED_PERMANENTLY;
-
-                return redirect()->to($redirectUrl, $statusCode);
             });
         });
 
@@ -52,6 +48,20 @@ class MissingPageRouter
         } catch (Exception $e) {
             return;
         }
+    }
+
+    protected function getRedirectUrlFromRedirects($redirects): string
+    {
+        if (is_array($redirects)) {
+            return $this->resolveRouterParameters($redirects[0]);
+        }
+
+        return $this->resolveRouterParameters($redirects);
+    }
+
+    protected function getStatusCodeFromRedirects($redirects): int
+    {
+        return is_array($redirects) ? $redirects[1] : Response::HTTP_MOVED_PERMANENTLY;
     }
 
     protected function resolveRouterParameters(string $redirectUrl): string

--- a/src/MissingPageRouter.php
+++ b/src/MissingPageRouter.php
@@ -31,11 +31,19 @@ class MissingPageRouter
     {
         $redirects = $this->redirector->getRedirectsFor($request);
 
-        collect($redirects)->each(function ($redirectUrl, $missingUrl) {
-            $this->router->get($missingUrl, function () use ($redirectUrl) {
-                $redirectUrl = $this->resolveRouterParameters($redirectUrl);
+        collect($redirects)->each(function ($redirects, $missingUrl) {
 
-                return redirect()->to($redirectUrl, Response::HTTP_MOVED_PERMANENTLY);
+            $this->router->get($missingUrl, function () use ($redirects) {
+
+                if (is_array($redirects)) {
+                    $redirectUrl = $this->resolveRouterParameters($redirects[0]);
+                } else {
+                    $redirectUrl = $this->resolveRouterParameters($redirects);
+                }
+
+                $statusCode = is_array($redirects) ? $redirects[1] : Response::HTTP_MOVED_PERMANENTLY;
+
+                return redirect()->to($redirectUrl, $statusCode);
             });
         });
 

--- a/tests/RedirectsMissingPagesTest.php
+++ b/tests/RedirectsMissingPagesTest.php
@@ -68,6 +68,19 @@ class RedirectsMissingPagesTest extends TestCase
     }
 
     /** @test */
+    public function it_can_optionally_set_the_redirect_status_code()
+    {
+        $this->app['config']->set('laravel-missing-page-redirector.redirects', [
+            '/temporarily-moved' => ['/just-for-now', 302],
+        ]);
+
+        $this->get('/temporarily-moved');
+
+        $this->assertRedirectedTo('/just-for-now');
+        $this->assertResponseStatus(302);
+    }
+
+    /** @test */
     public function it_can_use_optional_parameters()
     {
         $this->app['config']->set('laravel-missing-page-redirector.redirects', [


### PR DESCRIPTION
Currently the package always returns a 301 response code. This PR adds support to override the default code, with a different one using the syntax:

```php
    'redirects' => [
       'old-page' => ['/new-page', 302],
    ],
```