### PR TITLE
Add support for automatically handling query strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ Optional parameters are also... an option:
     ],
 ```
 
+If your missing page uses query strings, these are automatically supported without any additional configuration:
+
+```php
+    'redirects' => [
+       '/old-search' => '/new-search',
+    ],
+```
+
+When accessing ```/old-search?query=FooBar```, the request will automatically be redirected to ```/new-search?query=FooBar```
+
 ## Creating your own redirector
 
 By default this package will use the `Spatie\MissingPageRedirector\Redirector\ConfigurationRedirector` which will get its redirects from the config file. If you want to use another source for your redirects (for example a database) you can create your own redirector.

--- a/src/MissingPageRouter.php
+++ b/src/MissingPageRouter.php
@@ -52,6 +52,13 @@ class MissingPageRouter
             $redirectUrl = str_replace("{{$key}}", $value, $redirectUrl);
         }
 
-        return $redirectUrl;
+        return $redirectUrl . $this->appendQueryStringToUrl();
+    }
+
+    protected function appendQueryStringToUrl(): string
+    {
+        $queryString = $this->router->getCurrentRequest()->getQueryString();
+
+        return ($queryString ? '?' . $queryString : '');
     }
 }

--- a/tests/RedirectsMissingPagesTest.php
+++ b/tests/RedirectsMissingPagesTest.php
@@ -88,6 +88,27 @@ class RedirectsMissingPagesTest extends TestCase
     }
 
     /** @test */
+    public function it_automatically_appends_existing_query_strings_when_redirecting()
+    {
+        $this->app['config']->set('laravel-missing-page-redirector.redirects', [
+            '/old-page' => '/new-page',
+        ]);
+
+        $this->get('/old-page?param=1');
+
+        $this->assertRedirectedTo('/new-page?param=1');
+
+        $this->get('/old-page?param=1&param2=2');
+
+        $this->assertRedirectedTo('/new-page?param=1&param2=2');
+
+        $this->get('/old-page?param=1&param2=2&param3=3');
+
+        $this->assertRedirectedTo('/new-page?param=1&param2=2&param3=3');
+
+    }
+
+    /** @test */
     public function it_will_not_redirect_requests_that_are_not_404s()
     {
         $this->get('/response-code/500');


### PR DESCRIPTION
This PR adds support for automatically forwarding query strings:

When accessing ```/old-search?query=FooBar```, the request will automatically be redirected to ```/new-search?query=FooBar```
