### PR TITLE
Add Route was Hit event, including test

### DIFF
--- a/src/Events/RouteWasHit.php
+++ b/src/Events/RouteWasHit.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\MissingPageRedirector;
+namespace Spatie\MissingPageRedirector\Events;
 
 class RouteWasHit
 {

--- a/src/MissingPageRouter.php
+++ b/src/MissingPageRouter.php
@@ -33,7 +33,7 @@ class MissingPageRouter
 
         collect($redirects)->each(function ($redirects, $missingUrl) {
             $this->router->get($missingUrl, function () use ($redirects) {
-                event(new RouteWasHit($this->determineRedirectUrl($redirects)));
+                event(new RouteWasHit($this->determineRedirectUrl($redirects), $missingUrl));
 
                 return redirect()->to(
                     $this->determineRedirectUrl($redirects),

--- a/src/MissingPageRouter.php
+++ b/src/MissingPageRouter.php
@@ -33,6 +33,8 @@ class MissingPageRouter
 
         collect($redirects)->each(function ($redirects, $missingUrl) {
             $this->router->get($missingUrl, function () use ($redirects) {
+                event(new RouteWasHit($this->determineRedirectUrl($redirects)));
+
                 return redirect()->to(
                     $this->determineRedirectUrl($redirects),
                     $this->determineRedirectStatusCode($redirects)

--- a/src/MissingPageRouter.php
+++ b/src/MissingPageRouter.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Routing\Router;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Spatie\MissingPageRedirector\Events\RouteWasHit;
 use Spatie\MissingPageRedirector\Redirector\Redirector;
 
 class MissingPageRouter
@@ -32,7 +33,7 @@ class MissingPageRouter
         $redirects = $this->redirector->getRedirectsFor($request);
 
         collect($redirects)->each(function ($redirects, $missingUrl) {
-            $this->router->get($missingUrl, function () use ($redirects) {
+            $this->router->get($missingUrl, function () use ($redirects, $missingUrl) {
                 event(new RouteWasHit($this->determineRedirectUrl($redirects), $missingUrl));
 
                 return redirect()->to(

--- a/src/RouteWasHit.php
+++ b/src/RouteWasHit.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\MissingPageRedirector;
+
+class RouteWasHit
+{
+    public $route;
+
+    public function __construct($route)
+    {
+        $this->route = $route;
+    }
+}

--- a/src/RouteWasHit.php
+++ b/src/RouteWasHit.php
@@ -6,8 +6,12 @@ class RouteWasHit
 {
     public $route;
 
-    public function __construct($route)
+    public $missingUrl;
+
+    public function __construct(string $route, string $missingUrl)
     {
         $this->route = $route;
+
+        $this->missingUrl = $missingUrl;
     }
 }

--- a/tests/RedirectsMissingPagesTest.php
+++ b/tests/RedirectsMissingPagesTest.php
@@ -3,8 +3,8 @@
 namespace Spatie\MissingPageRedirector\Test;
 
 use Illuminate\Support\Facades\Event;
-use Spatie\MissingPageRedirector\Events\RouteWasHit;
 use Symfony\Component\HttpFoundation\Response;
+use Spatie\MissingPageRedirector\Events\RouteWasHit;
 
 class RedirectsMissingPagesTest extends TestCase
 {

--- a/tests/RedirectsMissingPagesTest.php
+++ b/tests/RedirectsMissingPagesTest.php
@@ -3,7 +3,7 @@
 namespace Spatie\MissingPageRedirector\Test;
 
 use Illuminate\Support\Facades\Event;
-use Spatie\MissingPageRedirector\RouteWasHit;
+use Spatie\MissingPageRedirector\Events\RouteWasHit;
 use Symfony\Component\HttpFoundation\Response;
 
 class RedirectsMissingPagesTest extends TestCase

--- a/tests/RedirectsMissingPagesTest.php
+++ b/tests/RedirectsMissingPagesTest.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\MissingPageRedirector\Test;
 
+use Illuminate\Support\Facades\Event;
+use Spatie\MissingPageRedirector\RouteWasHit;
 use Symfony\Component\HttpFoundation\Response;
 
 class RedirectsMissingPagesTest extends TestCase
@@ -106,5 +108,19 @@ class RedirectsMissingPagesTest extends TestCase
         $this->get('/response-code/500');
 
         $this->assertResponseStatus(500);
+    }
+
+    /** @test */
+    public function it_will_fire_an_event_when_a_route_is_hit()
+    {
+        Event::fake();
+
+        $this->app['config']->set('laravel-missing-page-redirector.redirects', [
+            '/old-segment/{parameter1?}/{parameter2?}' => '/new-segment/',
+        ]);
+
+        $this->get('/old-segment');
+
+        Event::assertDispatched(RouteWasHit::class);
     }
 }


### PR DESCRIPTION
I attempt to address Question 2 on Issue #22 with this PR.

I've added a `RouteWasHit` event in the `src` directory and tested it with Laravel's `Event::assertDispatched` in the following way:

```php
/** @test */
public function it_will_fire_an_event_when_a_route_is_hit()
{
    Event::fake();

    $this->app['config']->set('laravel-missing-page-redirector.redirects', [
        '/old-segment/{parameter1?}/{parameter2?}' => '/new-segment/',
    ]);

    $this->get('/old-segment');

    Event::assertDispatched(RouteWasHit::class);
}
```

I'll gladly revisit this code and hope this is a useful addition.