### PR TITLE
Correct year in Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All Notable changes to `laravel-missing-page-redirector` will be documented in this file
 
-## 1.3.0 - 2016-06-11
+## 1.3.0 - 2017-06-11
 
 - add `RouteWasHit`  event
 
-## 1.2.0 - 2016-01-23
+## 1.2.0 - 2017-01-23
 
 - add support for Laravel 5.4
 - drop support for Laravel 5.3


### PR DESCRIPTION
I noticed that `2016` was used to notify users of the additional `EventWasHit` event. Changed it to `2017`.