### PR TITLE
Feature - Redirect on any HTTP code besides 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Optional parameters are also... an option:
 ```
 
 By default it only redirects if the request has a ```404``` response code but it's possible to be redirected on any response code. 
-To achieve this you may change the ```status_code``` option to an array of response codes, leave it empty if you wish to be redirected no matter what the response code was sent to the URL.
+To achieve this you may change the ```status_code``` option to an array of response codes or leave it empty if you wish to be redirected no matter what the response code was sent to the URL.
 You may override this using the following syntax to achieve this:  
 
 ```php

--- a/README.md
+++ b/README.md
@@ -98,12 +98,12 @@ Optional parameters are also... an option:
     ],
 ```
 
-By default it only redirects if the request has a ```404``` response code but it's possible to be redirected on any response code. 
-To achieve this you may change the ```status_code``` option to an array of response codes or leave it empty if you wish to be redirected no matter what the response code was sent to the URL.
+By default it only redirects if the request has a `404` response code but it's possible to be redirected on any response code.
+To achieve this you may change the ```redirect_status_codes``` option to an array of response codes or leave it empty if you wish to be redirected no matter what the response code was sent to the URL.
 You may override this using the following syntax to achieve this:  
 
 ```php
-    'status_code' => [\Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND],
+    'redirect_status_codes' => [\Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND],
 ```
 
 It is also possible to optionally specify which http response code is used when performing the redirect. By default the ```301 Moved Permanently``` response code is set. You may override this using the following syntax:   

--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ Optional parameters are also... an option:
     ],
 ```
 
+By default it only redirects if the request has a ```404``` response code but it's possible to be redirected on any response code. 
+To achieve this you may change the ```status_code``` option to an array of response codes, leave it empty if you wish to be redirected no matter what the response code was sent to the URL.
+You may override this using the following syntax to achieve this:  
+
+```php
+    'status_code' => [\Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND],
+```
+
 It is also possible to optionally specify which http response code is used when performing the redirect. By default the ```301 Moved Permanently``` response code is set. You may override this using the following syntax:   
 
 ```php

--- a/config/missing-page-redirector.php
+++ b/config/missing-page-redirector.php
@@ -13,6 +13,7 @@ return [
      * It also it also accepts an array.
      * To trigger redirects on any HTTP code leave it empty
      */
+    'status_code' => \Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND,
     
     /*
      * When using the `ConfigurationRedirector` you can specify the redirects in this array.

--- a/config/missing-page-redirector.php
+++ b/config/missing-page-redirector.php
@@ -10,10 +10,9 @@ return [
     
     /*
      * This allows you to trigger the redirects on all kind of HTTP codes.
-     * It also it also accepts an array.
-     * To trigger redirects on any HTTP code leave it empty
+     * To trigger redirects on any HTTP code leave it as an empty array
      */
-    'status_code' => \Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND,
+    'redirect_status_codes' => [\Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND],
     
     /*
      * When using the `ConfigurationRedirector` you can specify the redirects in this array.

--- a/config/missing-page-redirector.php
+++ b/config/missing-page-redirector.php
@@ -7,7 +7,13 @@ return [
      * `Spatie\MissingPageRedirector\Redirector\Redirector`-interface
      */
     'redirector' => \Spatie\MissingPageRedirector\Redirector\ConfigurationRedirector::class,
-
+    
+    /*
+     * This allows you to trigger the redirects on all kind of HTTP codes.
+     * It also it also accepts an array.
+     * To trigger redirects on any HTTP code leave it empty
+     */
+    
     /*
      * When using the `ConfigurationRedirector` you can specify the redirects in this array.
      * You can use Laravel's route parameters here.

--- a/src/RedirectsMissingPages.php
+++ b/src/RedirectsMissingPages.php
@@ -12,10 +12,15 @@ class RedirectsMissingPages
     {
         $response = $next($request);
 
-        if ($response->getStatusCode() !== Response::HTTP_NOT_FOUND) {
-            return $response;
+        $allowedStatusCode = config('missing-page-redirector.status_code', [Response::HTTP_NOT_FOUND]);
+        if(!is_array($allowedStatusCode)){
+            $allowedStatusCode = is_integer($allowedStatusCode) ? [$allowedStatusCode] : [];
         }
 
+        if (!empty($allowedStatusCode) && !in_array($response->getStatusCode(), $allowedStatusCode)) {
+            return $response;
+        }
+        
         $redirectResponse = app(MissingPageRouter::class)->getRedirectFor($request);
 
         return $redirectResponse ?? $response;

--- a/src/RedirectsMissingPages.php
+++ b/src/RedirectsMissingPages.php
@@ -12,8 +12,8 @@ class RedirectsMissingPages
     {
         $response = $next($request);
 
-        $allowedStatusCodes = config('missing-page-redirector.redirect_status_codes', [Response::HTTP_NOT_FOUND]);
-
+        $allowedStatusCodes = config('missing-page-redirector.redirect_status_codes');
+        
         //If option is set as null or the response status code is not present in the config then skip redirects
         if (is_null($allowedStatusCodes) || (!empty($allowedStatusCodes) && !in_array($response->getStatusCode(), $allowedStatusCodes))) {
             return $response;

--- a/src/RedirectsMissingPages.php
+++ b/src/RedirectsMissingPages.php
@@ -12,12 +12,10 @@ class RedirectsMissingPages
     {
         $response = $next($request);
 
-        $allowedStatusCode = config('missing-page-redirector.status_code', [Response::HTTP_NOT_FOUND]);
-        if(!is_array($allowedStatusCode)){
-            $allowedStatusCode = is_integer($allowedStatusCode) ? [$allowedStatusCode] : [];
-        }
+        $allowedStatusCodes = config('missing-page-redirector.redirect_status_codes', [Response::HTTP_NOT_FOUND]);
 
-        if (!empty($allowedStatusCode) && !in_array($response->getStatusCode(), $allowedStatusCode)) {
+        //If option is set as null or the response status code is not present in the config then skip redirects
+        if (is_null($allowedStatusCodes) || (!empty($allowedStatusCodes) && !in_array($response->getStatusCode(), $allowedStatusCodes))) {
             return $response;
         }
         

--- a/tests/RedirectsMissingPagesTest.php
+++ b/tests/RedirectsMissingPagesTest.php
@@ -126,20 +126,28 @@ class RedirectsMissingPagesTest extends TestCase
     }
     
     /** @test */
-    public function it_will_redirect_depending_on_status_code_defined()
+    public function it_will_redirect_depending_on_redirect_status_codes_defined()
     {
-        $this->app['config']->set('missing-page-redirector.status_code', [404, 500]);
+        $this->app['config']->set('missing-page-redirector.redirect_status_codes', [404, 500]);
+        $this->app['config']->set('missing-page-redirector.redirects', [
+            '/non-existing-page' => '/existing-page',
+        ]);
+        
         $this
-            ->get('/response-code/500')
-            ->assertStatus(500);
+            ->get('non-existing-page')
+            ->assertStatus(Response::HTTP_MOVED_PERMANENTLY)
+            ->assertRedirect('/existing-page');
     }
     
     /** @test */
-    public function it_will_redirect_depending_on_any_status_code()
+    public function it_will_redirect_on_any_status_code()
     {
-        $this->app['config']->set('missing-page-redirector.status_code', []);
+        $this->app['config']->set('missing-page-redirector.redirect_status_codes', []);
+        $this->app['config']->set('missing-page-redirector.redirects', [
+            '/non-existing-page' => '/existing-page',
+        ]);
         $this
-            ->get('/response-code/401')
-            ->assertStatus(401);
+            ->get('non-existing-page')
+            ->assertRedirect('/existing-page');
     }
 }

--- a/tests/RedirectsMissingPagesTest.php
+++ b/tests/RedirectsMissingPagesTest.php
@@ -124,4 +124,22 @@ class RedirectsMissingPagesTest extends TestCase
 
         Event::assertDispatched(RouteWasHit::class);
     }
+    
+    /** @test */
+    public function it_will_redirect_depending_on_status_code_defined()
+    {
+        $this->app['config']->set('missing-page-redirector.status_code', [404, 500]);
+        $this
+            ->get('/response-code/500')
+            ->assertStatus(500);
+    }
+    
+    /** @test */
+    public function it_will_redirect_depending_on_any_status_code()
+    {
+        $this->app['config']->set('missing-page-redirector.status_code', []);
+        $this
+            ->get('/response-code/401')
+            ->assertStatus(401);
+    }
 }


### PR DESCRIPTION
Hello,

I wanted to use this awesome package by Spatie but I needed to redirect the user no matter the HTTP code received from the origin URL.
Right now the middleware only allows you to be redirected if the origin URL sends a 404 response code, with this pull request, you can define  with the option: "status_code" in the config file the response code on when the user user should be redirected(ex: 404 by default). It allows you to trigger the redirect on different response codes or on all response codes(by leaving an empty array)

Gabriel