### PR TITLE
Feature - Pass HTTP status code on "RouteWasHit" event.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ It is also possible to optionally specify which http response code is used when 
     ],
 ```
 
+You can also override the http response code without a redirect. Example:   
+
+```php
+    'redirects' => [
+       'deleted-page' => ['', 410],
+    ],
+```
+
+
 ## Creating your own redirector
 
 By default this package will use the `Spatie\MissingPageRedirector\Redirector\ConfigurationRedirector` which will get its redirects from the config file. If you want to use another source for your redirects (for example a database) you can create your own redirector.

--- a/src/Events/RouteWasHit.php
+++ b/src/Events/RouteWasHit.php
@@ -9,11 +9,14 @@ class RouteWasHit
 
     /** @var string */
     public $missingUrl;
+    
+    /** @var int */
+    public $statusCode;
 
-    public function __construct(string $route, string $missingUrl)
+    public function __construct(string $route, string $missingUrl, int $statusCode)
     {
         $this->route = $route;
-
         $this->missingUrl = $missingUrl;
+        $this->statusCode = $statusCode;
     }
 }

--- a/src/MissingPageRouter.php
+++ b/src/MissingPageRouter.php
@@ -35,12 +35,13 @@ class MissingPageRouter
         collect($redirects)->each(function ($redirects, $missingUrl) {
             $this->router->get($missingUrl, function () use ($redirects, $missingUrl) {
                 $redirectUrl = $this->determineRedirectUrl($redirects);
-
-                event(new RouteWasHit($redirectUrl, $missingUrl));
+                $statusCode = $this->determineRedirectStatusCode($redirects);
+                
+                event(new RouteWasHit($redirectUrl, $missingUrl, $statusCode));
 
                 return redirect()->to(
                     $redirectUrl,
-                    $this->determineRedirectStatusCode($redirects)
+                    $statusCode
                 );
             });
         });

--- a/src/MissingPageRouter.php
+++ b/src/MissingPageRouter.php
@@ -38,7 +38,11 @@ class MissingPageRouter
                 $statusCode = $this->determineRedirectStatusCode($redirects);
                 
                 event(new RouteWasHit($redirectUrl, $missingUrl, $statusCode));
-
+                
+                if(empty($redirectUrl) && !empty($statusCode)){
+                    response()->setStatusCode($statusCode);                    
+                }
+                
                 return redirect()->to(
                     $redirectUrl,
                     $statusCode

--- a/src/RedirectsMissingPages.php
+++ b/src/RedirectsMissingPages.php
@@ -4,7 +4,6 @@ namespace Spatie\MissingPageRedirector;
 
 use Closure;
 use Illuminate\Http\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 class RedirectsMissingPages
 {
@@ -17,8 +16,16 @@ class RedirectsMissingPages
         }
 
         $redirectResponse = app(MissingPageRouter::class)->getRedirectFor($request);
-
-        return $redirectResponse ?? $response;
+        if(!empty($redirectResponse)){
+            return $redirectResponse;
+        }
+        
+        $overrideStatusCode = app(MissingPageRouter::class)->getStatusCodeFor($request);
+        if($overrideStatusCode){
+            $response->setStatusCode($overrideStatusCode);
+        }
+        
+        return $response;
     }
 
     protected function shouldRedirect($response): bool

--- a/tests/RedirectsMissingPagesTest.php
+++ b/tests/RedirectsMissingPagesTest.php
@@ -166,4 +166,16 @@ class RedirectsMissingPagesTest extends TestCase
             ->get('/response-code/418')
             ->assertRedirect('/existing-page');
     }
+    
+     /** @test */
+    public function it_will_override_status_code_on_empty_redirect_url()
+    {
+        $this->app['config']->set('missing-page-redirector.redirects', [
+            '/temporarily-moved' => ['', 410],
+        ]);
+
+        $this
+            ->get('/temporarily-moved')
+            ->assertStatus(410);
+    }
 }


### PR DESCRIPTION
Hello,

I needed to change the HTTP status code on a matched URL(from the "redirects" config array), even if the Redirect URL is empty. Basically, it allows us to set HTTP status code even if the redirect URL is empty. This is useful IMO since allows us to trigger 404, 410, or any other status code defined in the redirect even without a redirect URL.

Cheers,
Gabriel