### PR TITLE
Fire an event when no redirect was found, fixes #39

### DIFF
--- a/src/Events/RedirectNotFound.php
+++ b/src/Events/RedirectNotFound.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\MissingPageRedirector\Events;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class RedirectNotFound
+{
+    /** @var Request */
+    public $request;
+
+    public function __construct(Request $request)
+    {
+        $this->request = $request;
+    }
+}

--- a/src/MissingPageRouter.php
+++ b/src/MissingPageRouter.php
@@ -8,6 +8,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Spatie\MissingPageRedirector\Events\RouteWasHit;
 use Spatie\MissingPageRedirector\Redirector\Redirector;
+use Spatie\MissingPageRedirector\Events\RedirectNotFound;
 
 class MissingPageRouter
 {
@@ -49,6 +50,7 @@ class MissingPageRouter
         try {
             return $this->router->dispatch($request);
         } catch (Exception $e) {
+            event(new RedirectNotFound($request));
             return;
         }
     }

--- a/tests/RedirectsMissingPagesTest.php
+++ b/tests/RedirectsMissingPagesTest.php
@@ -173,7 +173,7 @@ class RedirectsMissingPagesTest extends TestCase
     {
         Event::fake();
 
-        $this->get('/non-existing-route');
+        $this->get('/response-code/404');
 
         Event::assertDispatched(RedirectNotFound::class);
     }

--- a/tests/RedirectsMissingPagesTest.php
+++ b/tests/RedirectsMissingPagesTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\MissingPageRedirector\Test;
 
 use Illuminate\Support\Facades\Event;
+use Spatie\MissingPageRedirector\Events\RedirectNotFound;
 use Symfony\Component\HttpFoundation\Response;
 use Spatie\MissingPageRedirector\Events\RouteWasHit;
 
@@ -165,5 +166,15 @@ class RedirectsMissingPagesTest extends TestCase
         $this
             ->get('/response-code/418')
             ->assertRedirect('/existing-page');
+    }
+
+    /** @test */
+    public function it_will_fire_an_event_when_no_redirect_was_found()
+    {
+        Event::fake();
+
+        $this->get('/non-existing-route');
+
+        Event::assertDispatched(RedirectNotFound::class);
     }
 }


### PR DESCRIPTION
If I need to change anything, let me know. I'm not sure if I should add this to the readme, since the RouteWasHit event is also not mentioned in the readme.