### PR TITLE
add support for optionally preserving query parameters

### DIFF
--- a/config/missing-page-redirector.php
+++ b/config/missing-page-redirector.php
@@ -17,6 +17,8 @@ return [
         \Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND,
     ],
 
+    'preserve_query_parameters' => false,
+
     /*
      * When using the `ConfigurationRedirector` you can specify the redirects in this array.
      * You can use Laravel's route parameters here.

--- a/src/MissingPageRouter.php
+++ b/src/MissingPageRouter.php
@@ -4,11 +4,11 @@ namespace Spatie\MissingPageRedirector;
 
 use Exception;
 use Illuminate\Routing\Router;
-use Spatie\MissingPageRedirector\Events\RedirectNotFound;
-use Spatie\MissingPageRedirector\Events\RouteWasHit;
-use Spatie\MissingPageRedirector\Redirector\Redirector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Spatie\MissingPageRedirector\Events\RouteWasHit;
+use Spatie\MissingPageRedirector\Redirector\Redirector;
+use Spatie\MissingPageRedirector\Events\RedirectNotFound;
 
 class MissingPageRouter
 {
@@ -20,7 +20,7 @@ class MissingPageRouter
 
     public function __construct(Router $router, Redirector $redirector)
     {
-        $this->router     = $router;
+        $this->router = $router;
         $this->redirector = $redirector;
     }
 
@@ -39,7 +39,7 @@ class MissingPageRouter
                     $this->determineRedirectUrl($redirects),
                     $request
                 );
-                $statusCode  = $this->determineRedirectStatusCode($redirects);
+                $statusCode = $this->determineRedirectStatusCode($redirects);
 
                 event(new RouteWasHit($redirectUrl, $missingUrl, $statusCode));
 
@@ -86,10 +86,10 @@ class MissingPageRouter
 
     protected function maybePreserveQueryParameters(string $redirectUrl, Request $request): string
     {
-        if (!config('missing-page-redirector.preserve_query_parameters')) {
+        if (! config('missing-page-redirector.preserve_query_parameters')) {
             return $redirectUrl;
         }
 
-        return trim($redirectUrl . '?' . $request->getQueryString(), '?');
+        return trim($redirectUrl.'?'.$request->getQueryString(), '?');
     }
 }


### PR DESCRIPTION
This adds the ability to optionally preserve query parameters to the redirect URL.

There are some cases where you might have a URL that contains, for instance, UTM tracking params that need to be pushed to Google Tag Manager or some other service; this makes sure those parameters continue to be available to the target URL.