### PR TITLE
Removing unnecessary router instance + refactoring

### DIFF
--- a/src/Helpers/RoutesTransformer.php
+++ b/src/Helpers/RoutesTransformer.php
@@ -39,7 +39,7 @@ class RoutesTransformer
         $route = new Route(['GET', 'HEAD'], $missingUrl, null);
 
         return $route->setAction(RouteAction::parse($route->uri(), function () use ($route, $redirectUrl, $missingUrl) {
-            $statusCode  = self::determineRedirectStatusCode($redirectUrl);
+            $statusCode = self::determineRedirectStatusCode($redirectUrl);
             $redirectUrl = self::determineRedirectUrl($route, $redirectUrl);
 
             event(new RouteWasHit($redirectUrl, $missingUrl, $statusCode));

--- a/src/Helpers/RoutesTransformer.php
+++ b/src/Helpers/RoutesTransformer.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Spatie\MissingPageRedirector\Helpers;
+
+use Illuminate\Routing\Route;
+use Illuminate\Routing\RouteAction;
+use Illuminate\Routing\RouteCollection;
+use Spatie\MissingPageRedirector\Events\RouteWasHit;
+use Symfony\Component\HttpFoundation\Response;
+
+class RoutesTransformer
+{
+    /**
+     * @param array $redirects
+     *
+     * @return \Illuminate\Routing\RouteCollection
+     */
+    public static function transform(array $redirects): RouteCollection
+    {
+        $routes = new RouteCollection;
+
+        foreach ($redirects as $missingUrl => $redirectUrl) {
+            $routes->add(static::makeRoute($missingUrl, $redirectUrl));
+        }
+
+        return $routes;
+    }
+
+    /**
+     * Make route.
+     *
+     * @param string $missingUrl
+     * @param string|array $redirectUrl
+     *
+     * @return \Illuminate\Routing\Route
+     */
+    public static function makeRoute(string $missingUrl, $redirectUrl): Route
+    {
+        $route = new Route(['GET', 'HEAD'], $missingUrl, null);
+
+        return $route->setAction(RouteAction::parse($route->uri(), function () use ($route, $redirectUrl, $missingUrl) {
+            $statusCode  = self::determineRedirectStatusCode($redirectUrl);
+            $redirectUrl = self::determineRedirectUrl($route, $redirectUrl);
+
+            event(new RouteWasHit($redirectUrl, $missingUrl, $statusCode));
+
+            return redirect()->to($redirectUrl, $statusCode);
+        }));
+    }
+
+    /**
+     * @param  \Illuminate\Routing\Route  $route
+     * @param  string|array               $redirectUrl
+     *
+     * @return string
+     */
+    private static function determineRedirectUrl(Route $route, $redirectUrl): string
+    {
+        if (is_array($redirectUrl)) {
+            $redirectUrl = $redirectUrl[0];
+        }
+
+        foreach ($route->parameters() as $key => $value) {
+            $redirectUrl = str_replace("{{$key}}", $value, $redirectUrl);
+        }
+
+        return preg_replace('/\/{[\w-]+}/', '', $redirectUrl);
+    }
+
+    /**
+     * @param  string|array  $redirectUrl
+     *
+     * @return int
+     */
+    private static function determineRedirectStatusCode($redirectUrl): int
+    {
+        return is_array($redirectUrl)
+            ? $redirectUrl[1]
+            : Response::HTTP_MOVED_PERMANENTLY;
+    }
+}

--- a/src/Helpers/RoutesTransformer.php
+++ b/src/Helpers/RoutesTransformer.php
@@ -30,17 +30,17 @@ class RoutesTransformer
      * Make route.
      *
      * @param string $missingUrl
-     * @param string|array $redirectUrl
+     * @param string|array $redirects
      *
      * @return \Illuminate\Routing\Route
      */
-    public static function makeRoute(string $missingUrl, $redirectUrl): Route
+    public static function makeRoute(string $missingUrl, $redirects): Route
     {
-        $route = new Route(['GET', 'HEAD'], $missingUrl, null);
+        $route = new Route(['GET', 'HEAD'], $missingUrl, []);
 
-        return $route->setAction(RouteAction::parse($route->uri(), function () use ($route, $redirectUrl, $missingUrl) {
-            $statusCode = self::determineRedirectStatusCode($redirectUrl);
-            $redirectUrl = self::determineRedirectUrl($route, $redirectUrl);
+        return $route->setAction(RouteAction::parse($route->uri(), function () use ($route, $redirects, $missingUrl) {
+            $redirectUrl = self::determineRedirectUrl($route, $redirects);
+            $statusCode = self::determineRedirectStatusCode($redirects);
 
             event(new RouteWasHit($redirectUrl, $missingUrl, $statusCode));
 

--- a/src/MissingPageRedirectorServiceProvider.php
+++ b/src/MissingPageRedirectorServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\MissingPageRedirector;
 
-use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
 use Spatie\MissingPageRedirector\Redirector\Redirector;
 
@@ -15,14 +14,7 @@ class MissingPageRedirectorServiceProvider extends ServiceProvider
         ], 'config');
 
         $this->app->bind(Redirector::class, config('missing-page-redirector.redirector'));
-
-        $this->app->bind(MissingPageRouter::class, function () {
-            $router = new Router($this->app['events']);
-
-            $redirector = $this->app->make(Redirector::class);
-
-            return new MissingPageRouter($router, $redirector);
-        });
+        $this->app->bind(MissingPageRouter::class, MissingPageRouter::class);
     }
 
     public function register()

--- a/src/MissingPageRouter.php
+++ b/src/MissingPageRouter.php
@@ -6,7 +6,6 @@ use Exception;
 use Spatie\MissingPageRedirector\Events\RedirectNotFound;
 use Spatie\MissingPageRedirector\Helpers\RoutesTransformer;
 use Spatie\MissingPageRedirector\Redirector\Redirector;
-use Symfony\Component\HttpFoundation\Request;
 
 class MissingPageRouter
 {
@@ -19,11 +18,11 @@ class MissingPageRouter
     }
 
     /**
-     * @param \Illuminate\Http\Request|mixed $request
+     * @param \Symfony\Component\HttpFoundation\Request|mixed $request
      *
      * @return \Illuminate\Http\Response|mixed|void
      */
-    public function getRedirectFor(Request $request)
+    public function getRedirectFor($request)
     {
         $routes = RoutesTransformer::transform(
             $this->redirector->getRedirectsFor($request)

--- a/src/MissingPageRouter.php
+++ b/src/MissingPageRouter.php
@@ -3,7 +3,6 @@
 namespace Spatie\MissingPageRedirector;
 
 use Exception;
-use Illuminate\Routing\Router;
 use Spatie\MissingPageRedirector\Events\RedirectNotFound;
 use Spatie\MissingPageRedirector\Helpers\RoutesTransformer;
 use Spatie\MissingPageRedirector\Redirector\Redirector;
@@ -22,7 +21,7 @@ class MissingPageRouter
     /**
      * @param \Illuminate\Http\Request|mixed $request
      *
-     * @return \Illuminate\Http\Response|null
+     * @return \Illuminate\Http\Response|mixed|void
      */
     public function getRedirectFor(Request $request)
     {
@@ -35,7 +34,7 @@ class MissingPageRouter
         } catch (Exception $e) {
             event(new RedirectNotFound($request));
 
-            return null;
+            return;
         }
     }
 }

--- a/src/MissingPageRouter.php
+++ b/src/MissingPageRouter.php
@@ -4,80 +4,38 @@ namespace Spatie\MissingPageRedirector;
 
 use Exception;
 use Illuminate\Routing\Router;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Spatie\MissingPageRedirector\Events\RouteWasHit;
-use Spatie\MissingPageRedirector\Redirector\Redirector;
 use Spatie\MissingPageRedirector\Events\RedirectNotFound;
+use Spatie\MissingPageRedirector\Helpers\RoutesTransformer;
+use Spatie\MissingPageRedirector\Redirector\Redirector;
+use Symfony\Component\HttpFoundation\Request;
 
 class MissingPageRouter
 {
-    /** @var \Illuminate\Routing\Router */
-    protected $router;
-
     /** @var \Spatie\MissingPageRedirector\Redirector\Redirector */
     protected $redirector;
 
-    public function __construct(Router $router, Redirector $redirector)
+    public function __construct(Redirector $redirector)
     {
-        $this->router = $router;
         $this->redirector = $redirector;
     }
 
     /**
-     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param \Illuminate\Http\Request|mixed $request
      *
      * @return \Illuminate\Http\Response|null
      */
     public function getRedirectFor(Request $request)
     {
-        $redirects = $this->redirector->getRedirectsFor($request);
-
-        collect($redirects)->each(function ($redirects, $missingUrl) {
-            $this->router->get($missingUrl, function () use ($redirects, $missingUrl) {
-                $redirectUrl = $this->determineRedirectUrl($redirects);
-                $statusCode = $this->determineRedirectStatusCode($redirects);
-
-                event(new RouteWasHit($redirectUrl, $missingUrl, $statusCode));
-
-                return redirect()->to(
-                    $redirectUrl,
-                    $statusCode
-                );
-            });
-        });
+        $routes = RoutesTransformer::transform(
+            $this->redirector->getRedirectsFor($request)
+        );
 
         try {
-            return $this->router->dispatch($request);
+            return $routes->match($request)->run();
         } catch (Exception $e) {
             event(new RedirectNotFound($request));
 
-            return;
+            return null;
         }
-    }
-
-    protected function determineRedirectUrl($redirects): string
-    {
-        if (is_array($redirects)) {
-            return $this->resolveRouterParameters($redirects[0]);
-        }
-
-        return $this->resolveRouterParameters($redirects);
-    }
-
-    protected function determineRedirectStatusCode($redirects): int
-    {
-        return is_array($redirects) ? $redirects[1] : Response::HTTP_MOVED_PERMANENTLY;
-    }
-
-    protected function resolveRouterParameters(string $redirectUrl): string
-    {
-        foreach ($this->router->getCurrentRoute()->parameters() as $key => $value) {
-            $redirectUrl = str_replace("{{$key}}", $value, $redirectUrl);
-        }
-
-        $redirectUrl = preg_replace('/\/{[\w-]+}/', '', $redirectUrl);
-
-        return $redirectUrl;
     }
 }

--- a/src/RedirectsMissingPages.php
+++ b/src/RedirectsMissingPages.php
@@ -7,6 +7,14 @@ use Illuminate\Http\Request;
 
 class RedirectsMissingPages
 {
+    /** @var \Spatie\MissingPageRedirector\MissingPageRouter */
+    protected $mpr;
+
+    public function __construct(MissingPageRouter $mpr)
+    {
+        $this->mpr = $mpr;
+    }
+
     public function handle(Request $request, Closure $next)
     {
         $response = $next($request);
@@ -15,11 +23,14 @@ class RedirectsMissingPages
             return $response;
         }
 
-        $redirectResponse = app(MissingPageRouter::class)->getRedirectFor($request);
-
-        return $redirectResponse ?? $response;
+        return $this->mpr->getRedirectFor($request) ?? $response;
     }
 
+    /**
+     * @param \Symfony\Component\HttpFoundation\Response|mixed $response
+     *
+     * @return bool
+     */
     protected function shouldRedirect($response): bool
     {
         $redirectStatusCodes = config('missing-page-redirector.redirect_status_codes');


### PR DESCRIPTION
I removed the `router` instance because it was an overkill to handle the routes.

We can use `Illuminate\Routing\RouteCollection::match($request)` method to check if the request match the missing urls.

I'm not sure if it's a breaking change but i'm leaving this PR here just to show you it's possible to have same behavior without the router. 

*Also, i did some refactoring*

**MERGE AT YOUR OWN RISK**