### PR TITLE
Use Laravel container on private Router - closes #77

### DIFF
--- a/src/MissingPageRedirectorServiceProvider.php
+++ b/src/MissingPageRedirectorServiceProvider.php
@@ -17,7 +17,7 @@ class MissingPageRedirectorServiceProvider extends ServiceProvider
         $this->app->bind(Redirector::class, config('missing-page-redirector.redirector'));
 
         $this->app->bind(MissingPageRouter::class, function ($app) {
-            $router = new Router($app['events']);
+            $router = new Router($app['events'], $app);
 
             $redirector = $app->make(Redirector::class);
 


### PR DESCRIPTION
closes #77

As the container parameter is nullable in `Illuminate\Routing\Router`'s constructor, an empty container is assigned in its constructor when no container is provided.

Since https://github.com/laravel/framework/pull/44339 introduced `Illuminate/Routing/Contracts/CallableDispatcher`, a router needs this interface bound to dispatch closure bound routes such as the ones registered here:

https://github.com/spatie/laravel-missing-page-redirector/blob/ba2bc5f2e9cf3be883c311c125c756903eae412d/src/MissingPageRouter.php#L42-L53

This PR

- Passes Laravel Container to the `Router` constructor in this package's Service Provider, so it has a container which knows how to build a `CallableDispatcher` instance.