### PR TITLE
fix php8.4 nullable is deprecated

### DIFF
--- a/src/Events/RouteWasHit.php
+++ b/src/Events/RouteWasHit.php
@@ -13,7 +13,7 @@ class RouteWasHit
     /** @var int|null */
     public $statusCode;
 
-    public function __construct(string $route, string $missingUrl, int $statusCode = null)
+    public function __construct(string $route, string $missingUrl, ?int $statusCode = null)
     {
         $this->route = $route;
 


### PR DESCRIPTION
fixes php8.4 warning

```
PHP Deprecated:  Spatie\MissingPageRedirector\Events\RouteWasHit::__construct(): Implicitly marking parameter $statusCode as nullable is deprecated, the explicit nullable type must be used instead in ./src/Events/RouteWasHit.php on line 16
```